### PR TITLE
replaced .slice() with .replace()

### DIFF
--- a/header.php
+++ b/header.php
@@ -41,7 +41,7 @@
 				<script>
 					// Variables
 						// Set largeBreakpoint to $large-breakpoint from our SASS _variables
-						const largeBreakpoint = getComputedStyle(document.body).getPropertyValue('--large-breakpoint').slice(0,3);
+						const largeBreakpoint = getComputedStyle(document.body).getPropertyValue('--large-breakpoint').replace(/\D/g,'');
 
 						// Set navBar for easy access
 						const navBar = document.getElementById('nav-id');


### PR DESCRIPTION
there was a difference between chrome and mozilla, where mozilla was counting from 0 and chrome was counting from 1. So I used the replace function instead during the largeBreakpoint assignment to remove any letters at all